### PR TITLE
Support export of cards and/or contacts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,7 @@
             <div class="vcard">
                 <input class="upload" type="file" accept="text/vcard">
                 <button class="close">x</button>
+                <button class="save" title="Save all">dl</button>
                 <h2></h2>
                 <ul class="contacts"></ul>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
             <li class="contact">
                 <div class="contact-header">
                     <img />
+                    <button class="save" title="Save vCard">dl</button>
                     <h3></h3>
                     <em></em>
                 </div>

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -13,6 +13,7 @@ export default class CardBoard {
 
         this.cardCount += 1;
         ui.element('button.close', clone).onclick = this.removeCardColumn;
+        ui.element('button.save', clone).onclick = () => this.downloadCard(id);
         ui.element('input.upload', clone).onchange = (ev) => this.loadVCardFile(ev);
         ui.element('.vcard', clone).id = id;
 
@@ -21,6 +22,16 @@ export default class CardBoard {
 
         this.vCards[id] = new VCard(id);
         ui.element(`#${id} input`).click();
+    }
+
+    downloadCard(cardID: string) {
+        const card = this.vCards[cardID];
+
+        if (!card) {
+            throw new Error("Card '${cardID}' no longer exists.");
+        }
+
+        card.download();
     }
 
     removeCardColumn(event: Event) {

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -43,6 +43,28 @@ export default class Contact {
         this.properties = properties;
     }
 
+    download() {
+        const a = document.createElement('a'),
+            data = this.export() + '\r\n';
+
+        a.setAttribute('download', `${this.#displayAs().replace(' ', '-').toLowerCase()}.vcf`);
+        a.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`);
+        a.style.display = 'none';
+
+        document.body.appendChild(a).click();
+        document.body.removeChild(a);
+    }
+
+    export() {
+        const data = [];
+
+        for (const property of this.properties || []) {
+            data.push(property.export());
+        }
+
+        return data.join('\r\n');
+    }
+
     vCard() {
         const clone = this.template.cloneNode(true) as HTMLElement,
             sections = new ContactDetail(clone);

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -51,15 +51,12 @@ export default class VCard {
     }
 
     #contactFromVCard(vCard: string): Contact {
-        const properties = [];
+        const properties = [],
+            unfoldedLines = this.#unfoldLines(vCard);
 
-        for (const line of this.#unfoldLines(vCard)) {
-            if (!line) {
-                continue;
-            }
-
+        for (const unfoldedLine of unfoldedLines) {
             try {
-                properties.push(new VCardProperty(line));
+                properties.push(new VCardProperty(vCard, unfoldedLine));
             } catch (e) {
                 console.warn(`Oops! ${e}`);
             }
@@ -80,9 +77,10 @@ export default class VCard {
 
     // Split continuous lines on CRLF followed by space or tab.
     // Section 3.2 of RFC 6350: "Line Delimiting and Folding".
-    #unfoldLines(vCard: string): string[] {
-        const unfolded = vCard.replace(/\r\n[\t\u0020]/g, '');
-
-        return unfolded.split('\r\n').map(v => v);
+    #unfoldLines(foldedLines: string): string[] {
+        return foldedLines
+            .replace(/\r\n[\t\u0020]/g, '')
+            .split('\r\n')
+            .map(v => v);
     }
 }

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -19,9 +19,12 @@ export default class VCard {
         this.#forFile(filename);
 
         for (const vCard of vcfData.matchAll(this.#cardRegex)) {
-            const contact = this.#contactFromVCard(vCard[0]);
+            const contact = this.#contactFromVCard(vCard[0]),
+                contactCard = contact.vCard();
 
-            ui.element('.contacts', this.column).append(contact.vCard());
+            ui.element('.save', contactCard).onclick = () => contact.download();
+
+            ui.element('.contacts', this.column).append(contactCard);
         }
     }
 

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -81,6 +81,6 @@ export default class VCard {
         return foldedLines
             .replace(/\r\n[\t\u0020]/g, '')
             .split('\r\n')
-            .map(v => v);
+            .filter(v => v);
     }
 }

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -4,6 +4,7 @@ import * as ui from "./ui.js"
 
 export default class VCard {
     #cardRegex = /BEGIN:VCARD([\w\W]*?)END:VCARD/g;
+    contacts: Contact[] = [];
     column: HTMLDivElement;
     id: string;
     filename: string | undefined;
@@ -25,7 +26,28 @@ export default class VCard {
             ui.element('.save', contactCard).onclick = () => contact.download();
 
             ui.element('.contacts', this.column).append(contactCard);
+            this.contacts.push(contact);
         }
+    }
+
+    download() {
+        const a = document.createElement('a'),
+            data = this.export() + '\r\n';
+
+        a.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`);
+        a.setAttribute('download', `${this.filename}`);
+        a.style.display = 'none';
+
+        document.body.appendChild(a).click();
+        document.body.removeChild(a);
+    }
+
+    export() {
+        const cards: string[] = [];
+
+        this.contacts.forEach(c => cards.push(c.export()));
+
+        return cards.join('\r\n');
     }
 
     #contactFromVCard(vCard: string): Contact {

--- a/src/vcards/encoding.ts
+++ b/src/vcards/encoding.ts
@@ -3,10 +3,10 @@ import {Parameter} from "./properties.js";
 const encoder = new TextEncoder(),
     decoder = new TextDecoder();
 
-export function decodeComponents<Type extends {[key: string]: string}>(
-    components: Type,
-    parameters: Parameter[]
-): Type {
+export function decodeComponents<T extends {[key: string]: string}>(
+    components: T,
+    parameters: Parameter[],
+): T {
     for (const [key, value] of Object.entries(components)) {
         Object.assign(components, {[key]: decodeString(value, parameters)});
     }
@@ -32,8 +32,15 @@ export function decodeQuotedPrintable(value: string) {
     return decoder.decode(new Uint8Array(bytes));
 }
 
-export function encodeComponents(components: string[], parameters: Parameter[]): string {
-    return components.map(v => encodeString(v, parameters)).join(';');
+export function encodeComponents<T extends {[key: string]: string}>(
+    components: T,
+    parameters: Parameter[],
+): T {
+    for (const [key, value] of Object.entries(components)) {
+        Object.assign(components, {[key]: encodeString(value, parameters)});
+    }
+
+    return components;
 }
 
 export function encodeString(value: string, parameters: Parameter[]): string {

--- a/src/vcards/encoding.ts
+++ b/src/vcards/encoding.ts
@@ -1,6 +1,7 @@
 import {Parameter} from "./properties.js";
 
-const decoder = new TextDecoder();
+const encoder = new TextEncoder(),
+    decoder = new TextDecoder();
 
 export function decodeComponents<Type extends {[key: string]: string}>(
     components: Type,
@@ -29,4 +30,28 @@ export function decodeQuotedPrintable(value: string) {
     );
 
     return decoder.decode(new Uint8Array(bytes));
+}
+
+export function encodeComponents(components: string[], parameters: Parameter[]): string {
+    return components.map(v => encodeString(v, parameters)).join(';');
+}
+
+export function encodeString(value: string, parameters: Parameter[]): string {
+    const encoding = parameters.find(p => 'ENCODING' === p.name)?.value;
+
+    if ('QUOTED-PRINTABLE' === encoding) {
+        return encodeQuotedPrintable(value);
+    }
+
+    return value;
+}
+
+export function encodeQuotedPrintable(value: string) {
+    let encoded = '';
+
+    encoder.encode(value).forEach((byte: number) => {
+        encoded += `=${byte.toString(16).toUpperCase()}`;
+    });
+
+    return encoded;
 }

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -51,6 +51,10 @@ export class VCardProperty {
         }
     }
 
+    export(): string {
+        return `${this.name}:${this.value.export()}`
+    }
+
     type(): string {
         return this.parameters.find(
             (p) => 'TYPE' === p.name || !p.name

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -47,7 +47,7 @@ export class VCardProperty {
             case 'N': this.value = new NameValue(value, this.parameters); break;
             case 'ADR': this.value = new AddressValue(value, this.parameters); break;
             case 'PHOTO': this.value = new PhotoValue(value, this.parameters, folded); break;
-            default: this.value = new SimpleValue(value);
+            default: this.value = new SimpleValue(value, this.parameters);
         }
     }
 

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -32,12 +32,12 @@ export class VCardProperty {
     parameters: Parameter[];
     value: ValueFormatter;
 
-    constructor(line: string) {
-        const [propString, value] = <[string, string]>line.split(/:(.*)/),
+    constructor(folded: string, unfolded: string) {
+        const [propString, value] = <[string, string]>unfolded.split(/:(.*)/),
             [property, ...rawParams] = <[Property, ...[string]]>propString.split(';');
 
         if (!Object.values(Property).includes(property)) {
-            throw new Error(`Unhandled VCF line: '${line}'`);
+            throw new Error(`Unhandled VCF line: '${unfolded}'`);
         }
 
         this.name = property;
@@ -46,7 +46,7 @@ export class VCardProperty {
         switch (property) {
             case 'N': this.value = new NameValue(value, this.parameters); break;
             case 'ADR': this.value = new AddressValue(value, this.parameters); break;
-            case 'PHOTO': this.value = new PhotoValue(value, this.parameters); break;
+            case 'PHOTO': this.value = new PhotoValue(value, this.parameters, folded); break;
             default: this.value = new SimpleValue(value);
         }
     }

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -52,7 +52,9 @@ export class VCardProperty {
     }
 
     export(): string {
-        return `${this.name}:${this.value.export()}`
+        const propertiesPart = this.name;
+
+        return `${propertiesPart}:${this.value.export(propertiesPart.length + 1)}`
     }
 
     type(): string {

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -4,11 +4,18 @@ import PhotoValue from "./properties/photo.js";
 import {SimpleValue, ValueFormatter} from "./properties/simple.js";
 
 export enum Property {
-    begin = 'BEGIN', end = 'END', version = 'VERSION',
-    formattedName = 'FN', name = 'N', photo = 'PHOTO',
-    address = 'ADR',
-    phone = 'TEL', email = 'EMAIL',
-    orgTitle = 'TITLE', orgName = 'ORG',
+    begin = 'BEGIN', end = 'END', source =  'SOURCE', kind = 'KIND', xml = 'XML',   // General Properties
+    formattedName = 'FN', name = 'N', nickname = 'NICKNAME', photo = 'PHOTO',       // Identification Properties
+        birthday = 'BDAY', anniversary = 'ANNIVERSARY', gender = 'GENDER',          //     ...
+    address = 'ADR',                                                                // Delivery Addressing Properties
+    phone = 'TEL', email = 'EMAIL', impp = 'IMPP', lang = 'LANG',                   // Communications Properties
+    timezone = 'TZ', geo = 'GEO',                                                   // Geographical Properties
+    orgTitle = 'TITLE', orgRole = 'ROLE', orgName = 'ORG',                          // Organizational Properties
+        logo = 'LOGO', member = 'MEMBER', related = 'RELATED',                      //     ...
+    categories = 'CATEGORIES', note = 'NOTE', product = 'PRODID', revision = 'REV', // Explanatory Properties
+        sound = 'SOUND', uid = 'UID', pidmap = 'CLIENTPIDMAP', url = 'URL', version = 'VERSION',    //   ...
+    key = 'KEY',                                                                    // Security Properties
+    busyUrl = 'FBURL', calUserUri = 'CALADRURI', calUri = 'CALURI',                 // Calendar Properties
 };
 
 export type Parameter = {

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -52,9 +52,15 @@ export class VCardProperty {
     }
 
     export(): string {
-        const propertiesPart = this.name;
+        const parameters = [this.name, ...this.parameters.map(({name, value}) => {
+            if (name && value) {
+                return `${name}=${value}`;
+            }
 
-        return `${propertiesPart}:${this.value.export(propertiesPart.length + 1)}`
+            return name || value;
+        })].join(';');
+
+        return `${parameters}:${this.value.export(parameters.length + 1)}`
     }
 
     type(): string {

--- a/src/vcards/properties.ts
+++ b/src/vcards/properties.ts
@@ -43,7 +43,7 @@ export class VCardProperty {
         const [propString, value] = <[string, string]>unfolded.split(/:(.*)/),
             [property, ...rawParams] = <[Property, ...[string]]>propString.split(';');
 
-        if (!Object.values(Property).includes(property)) {
+        if (!Object.values(Property).includes(property) && !property.startsWith('X-')) {
             throw new Error(`Unhandled VCF line: '${unfolded}'`);
         }
 

--- a/src/vcards/properties/address.ts
+++ b/src/vcards/properties/address.ts
@@ -31,4 +31,12 @@ export default class AddressValue implements ValueFormatter {
 
         return Object.values(this.components).filter(v => v).join(', ');
     }
+
+    export() {
+        if (!this.components) {
+            throw new Error("Contact is missing name components for conversion.");
+        }
+
+        return Object.values(this.components).join(';');
+    }
 }

--- a/src/vcards/properties/name.ts
+++ b/src/vcards/properties/name.ts
@@ -11,7 +11,7 @@ export default class NameValue implements ValueFormatter {
         suffixes: string,
     }|undefined;
     formatted: string;
-    original: any;
+    original: string;
 
     constructor(rawValue: string, parameters: Parameter[]) {
         this.original = rawValue;

--- a/src/vcards/properties/name.ts
+++ b/src/vcards/properties/name.ts
@@ -29,4 +29,15 @@ export default class NameValue implements ValueFormatter {
 
         return Object.values(this.components).filter(v => v).join(' ');
     }
+
+    export() {
+        if (!this.components) {
+            throw new Error("Contact is missing name components for conversion.");
+        }
+
+        const c = this.components,
+            values = [c.familyNames, c.givenNames, c.otherNames, c.prefixes, c.suffixes];
+
+        return values.join(';');
+    }
 }

--- a/src/vcards/properties/name.ts
+++ b/src/vcards/properties/name.ts
@@ -37,11 +37,8 @@ export default class NameValue implements ValueFormatter {
             throw new Error("Contact is missing name components for conversion.");
         }
 
-        const c = this.components;
+        const c = encodeComponents(this.components, this.parameters);
 
-        return encodeComponents(
-            [c.familyNames, c.givenNames, c.otherNames, c.prefixes, c.suffixes],
-            this.parameters,
-        );
+        return [c.familyNames, c.givenNames, c.otherNames, c.prefixes, c.suffixes].join(';');
     }
 }

--- a/src/vcards/properties/name.ts
+++ b/src/vcards/properties/name.ts
@@ -1,4 +1,4 @@
-import {decodeComponents} from "../encoding.js";
+import {decodeComponents, encodeComponents} from "../encoding.js";
 import {Parameter} from "../properties.js";
 import {ValueFormatter} from "./simple.js";
 
@@ -12,10 +12,12 @@ export default class NameValue implements ValueFormatter {
     }|undefined;
     formatted: string;
     original: string;
+    parameters: Parameter[];
 
     constructor(rawValue: string, parameters: Parameter[]) {
         this.original = rawValue;
         this.formatted = this.extract(parameters);
+        this.parameters = parameters;
     }
 
     extract(parameters: Parameter[]) {
@@ -35,9 +37,11 @@ export default class NameValue implements ValueFormatter {
             throw new Error("Contact is missing name components for conversion.");
         }
 
-        const c = this.components,
-            values = [c.familyNames, c.givenNames, c.otherNames, c.prefixes, c.suffixes];
+        const c = this.components;
 
-        return values.join(';');
+        return encodeComponents(
+            [c.familyNames, c.givenNames, c.otherNames, c.prefixes, c.suffixes],
+            this.parameters,
+        );
     }
 }

--- a/src/vcards/properties/photo.ts
+++ b/src/vcards/properties/photo.ts
@@ -26,13 +26,11 @@ export default class PhotoValue implements ValueFormatter {
         return PhotoValue.default();
     }
 
-    export() {
-        const padLength = 'PHOTO:'.length;
-
+    export(parametersLength: number) {
         return this.original
-            .padStart(this.original.length + padLength, '-')
+            .padStart(this.original.length + parametersLength, '-')
             .replace(/(?<=.{1,64})(.{1,63})/g, '$1\r\n ')
-            .replace(new RegExp(`^-{${padLength}}`), '')
+            .replace(new RegExp(`^-{${parametersLength}}`), '')
             .trim() + '\r\n';
     }
 }

--- a/src/vcards/properties/photo.ts
+++ b/src/vcards/properties/photo.ts
@@ -27,12 +27,12 @@ export default class PhotoValue implements ValueFormatter {
     }
 
     export() {
-        const padLength = 'PHOTO:'.length,
-            padRegex = new RegExp(`/^-{${padLength}}/`);
+        const padLength = 'PHOTO:'.length;
 
         return this.original
             .padStart(this.original.length + padLength, '-')
-            .replace(/(.{1,64})/g, '$1\r\n ')
-            .replace(padRegex, '');
+            .replace(/(?<=.{1,64})(.{1,63})/g, '$1\r\n ')
+            .replace(new RegExp(`^-{${padLength}}`), '')
+            .trim() + '\r\n';
     }
 }

--- a/src/vcards/properties/photo.ts
+++ b/src/vcards/properties/photo.ts
@@ -2,11 +2,13 @@ import {Parameter} from "../properties.js";
 import {ValueFormatter} from "./simple.js";
 
 export default class PhotoValue implements ValueFormatter {
+    folded: string;
     formatted: string;
     original: string;
 
-    constructor(rawValue: string, parameters: Parameter[]) {
+    constructor(rawValue: string, parameters: Parameter[], folded?: string) {
         this.original = rawValue;
+        this.folded = folded || rawValue;
         this.formatted = this.extract(parameters);
     }
 
@@ -27,9 +29,13 @@ export default class PhotoValue implements ValueFormatter {
     }
 
     export(parametersLength: number) {
+        const findAfter = this.folded.search(/^PHOTO(;(.*))?:/m),
+            foldedAt = this.folded.indexOf('\r\n ', findAfter),
+            foldLength = foldedAt - findAfter;
+
         return this.original
             .padStart(this.original.length + parametersLength, '-')
-            .replace(/(?<=.{1,64})(.{1,63})/g, '$1\r\n ')
+            .replace(new RegExp(`(?<=.{1,${foldLength}})(.{1,${foldLength-1}})`, 'g'), '$1\r\n ')
             .replace(new RegExp(`^-{${parametersLength}}`), '')
             .trim() + '\r\n';
     }

--- a/src/vcards/properties/photo.ts
+++ b/src/vcards/properties/photo.ts
@@ -3,7 +3,7 @@ import {ValueFormatter} from "./simple.js";
 
 export default class PhotoValue implements ValueFormatter {
     formatted: string;
-    original: any;
+    original: string;
 
     constructor(rawValue: string, parameters: Parameter[]) {
         this.original = rawValue;
@@ -24,5 +24,15 @@ export default class PhotoValue implements ValueFormatter {
         console.warn(`Photo has unknown/unsupported encoding '${encoding}'.`);
 
         return PhotoValue.default();
+    }
+
+    export() {
+        const padLength = 'PHOTO:'.length,
+            padRegex = new RegExp(`/^-{${padLength}}/`);
+
+        return this.original
+            .padStart(this.original.length + padLength, '-')
+            .replace(/(.{1,64})/g, '$1\r\n ')
+            .replace(padRegex, '');
     }
 }

--- a/src/vcards/properties/simple.ts
+++ b/src/vcards/properties/simple.ts
@@ -1,3 +1,4 @@
+import {decodeString, encodeString} from "../encoding.js";
 import {Parameter} from "../properties.js";
 
 export interface ValueFormatter {
@@ -11,12 +12,14 @@ export interface ValueFormatter {
 export class SimpleValue implements ValueFormatter {
     formatted: string;
     original: string;
+    parameters: Parameter[];
 
-    constructor(rawValue: string) {
+    constructor(rawValue: string, parameters: Parameter[]) {
         this.original = rawValue;
+        this.parameters = parameters;
         this.formatted = this.extract();
     }
 
-    extract = () => this.original;
-    export = () => this.original;
+    extract = () => decodeString(this.original, this.parameters);
+    export = () => encodeString(this.formatted, this.parameters);
 }

--- a/src/vcards/properties/simple.ts
+++ b/src/vcards/properties/simple.ts
@@ -5,6 +5,7 @@ export interface ValueFormatter {
     formatted: string;
     original: string;
     extract(parameters: Parameter[]): string;
+    export(): string;
 }
 
 export class SimpleValue implements ValueFormatter {
@@ -17,4 +18,5 @@ export class SimpleValue implements ValueFormatter {
     }
 
     extract = () => this.original;
+    export = () => this.original;
 }

--- a/src/vcards/properties/simple.ts
+++ b/src/vcards/properties/simple.ts
@@ -5,7 +5,7 @@ export interface ValueFormatter {
     formatted: string;
     original: string;
     extract(parameters: Parameter[]): string;
-    export(): string;
+    export(parametersLength?: number): string;
 }
 
 export class SimpleValue implements ValueFormatter {


### PR DESCRIPTION
This adds a download button to both card columns, and the contacts contained therein.

VCF downloads are generated by either calling `export()` on the contact directly, or `downloadCard()` on the main `CardBoard` class which will eventually trigger `Contact.export` via the `VCard` instances' `download` methods.

In order to ensure any valid vcf is output (roughly*) the same as it goes in, this PR also adds all known properties according to RFC 6350. While they're not handled, it's enough to get them included in the generated VCF when a card is exported as-is.