### PR TITLE
Collapsible Contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run `npx http-server` in the source dir and head to localhost:8080.
 ### vCards
 * [ ] Add new contact
 * [x] Show contact summaries
-  * [ ] Expand to show all properties
+  * [x] Expand to show all properties
 * [x] Rearrange contacts in the cards
 * [x] Drag and drop to move contacts between vCards
   * [ ] Hold shift/alt to create a copy instead

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,7 +107,7 @@ li.contact {
     list-style: none;
     margin: 0 0 1vw;
     overflow: auto;
-    padding: 0 0 1vh;
+    padding: 0;
 }
 li.contact.hovering {
     margin: 4vh 0 1vh;
@@ -120,9 +120,6 @@ li.contact.hovering::before {
     position: absolute;
     margin-left: -0.9rem;
     margin-top: -2.5rem;
-}
-li.contact > *:not(.contact-header):not(:empty) {
-    padding: 6px 6px 0;
 }
 .contact-header {
     background-color: #3a4f4d;
@@ -150,6 +147,9 @@ li.contact > *:not(.contact-header):not(:empty) {
 .contact-header button i {
     font-size: 20px;
     padding-top: 2px;
+}
+li.contact ul {
+    padding: 6px 6px 1vh;
 }
 li.contact ul.hidden {
     display: none;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -135,6 +135,11 @@ li.contact > *:not(.contact-header):not(:empty) {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+.contact-header em {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .contact-header img {
     border-radius: 4px;
     float: left;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -144,6 +144,12 @@ li.contact.hovering::before {
     margin-right: 8px;
     width: 40px;
 }
+.contact-header button:not(.expand) {
+    display: none;
+}
+.contact-header:hover button {
+    display: inline-block;
+}
 .contact-header button i {
     font-size: 20px;
     padding-top: 2px;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -151,6 +151,9 @@ li.contact > *:not(.contact-header):not(:empty) {
     font-size: 20px;
     padding-top: 2px;
 }
+li.contact ul.hidden {
+    display: none;
+}
 .contact-detail {
     text-wrap: nowrap;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -150,6 +150,9 @@ li.contact.hovering::before {
 .contact-header:hover button {
     display: inline-block;
 }
+.contact-header:hover button.expand {
+    color: #f5efe9;
+}
 .contact-header button i {
     font-size: 20px;
     padding-top: 2px;

--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
                     <h3></h3>
                     <em></em>
                 </div>
-                <ul></ul>
+                <ul class="hidden"></ul>
             </li>
         </template>
 

--- a/public/index.html
+++ b/public/index.html
@@ -42,11 +42,14 @@
             <li class="contact" draggable="true">
                 <div class="contact-header">
                     <img draggable="false" />
-                    <button class="remove" title="Delete Contact">
-                        <i class="material-symbols-outlined">delete</i>
+                    <button class="expand" title="Show details">
+                        <i class="material-symbols-outlined">expand_more</i>
                     </button>
                     <button class="save" title="Save vCard">
                         <i class="material-symbols-outlined">download</i>
+                    </button>
+                    <button class="remove" title="Delete contact">
+                        <i class="material-symbols-outlined">delete</i>
                     </button>
                     <h3></h3>
                     <em></em>

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -48,7 +48,7 @@ export default class Contact {
         const a = document.createElement('a'),
             data = this.export() + '\r\n';
 
-        a.setAttribute('download', `${this.#displayAs().replace(' ', '-').toLowerCase()}.vcf`);
+        a.setAttribute('download', `${this.#displayPrimary().replace(' ', '-').toLowerCase()}.vcf`);
         a.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`);
         a.style.display = 'none';
 
@@ -85,8 +85,8 @@ export default class Contact {
         const clone = this.template.cloneNode(true) as HTMLElement;
 
         ui.element('.contact', clone).id = this.id;
-        ui.element('h3', clone).innerText = this.#displayAs();
-        ui.element('em', clone).innerText = this.#displayOrg();
+        ui.element('h3', clone).innerText = this.#displayPrimary();
+        ui.element('em', clone).innerText = this.#displaySecondary();
         ui.image('img', clone).src = this.#prop(Property.photo) || PhotoValue.default();
 
         this.appendPropertiesHTML('vcard-contact-detail', ui.element('ul', clone), item => ({
@@ -118,7 +118,7 @@ export default class Contact {
         });
     }
 
-    #displayAs() {
+    #displayPrimary() {
         const n = this.#prop(Property.name),
             fn = this.#prop(Property.formattedName);
 
@@ -132,15 +132,25 @@ export default class Contact {
         return this.#prop(Property.email) || 'Unknown';
     }
 
-    #displayOrg() {
-        const title = this.#prop(Property.orgTitle),
-            organisation = this.#prop(Property.orgName);
+    #displaySecondary() {
+        const [email, phone, title, organisation] = [
+            this.#prop(Property.email),
+            this.#prop(Property.phone),
+            this.#prop(Property.orgTitle),
+            this.#prop(Property.orgName),
+        ];
 
+        if (phone || email) {
+            return phone || email;
+        }
         if (organisation && title) {
             return `${title}, ${organisation}`;
         }
+        if (organisation || title) {
+            return organisation || title;
+        }
 
-        return organisation || title;
+        return this.properties[0]?.value.formatted || '';
     }
 
     #prop(property: Property): string {

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -44,9 +44,11 @@ export default class Contact {
         ];
     }
 
-    download() {
+    download(event: Event) {
         const a = document.createElement('a'),
             data = this.export() + '\r\n';
+
+        event.stopPropagation();
 
         a.setAttribute('download', `${this.#displayPrimary().replace(' ', '-').toLowerCase()}.vcf`);
         a.setAttribute('href', `data:text/plain;charset=utf-8,${encodeURIComponent(data)}`);

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -65,9 +65,12 @@ export default class VCard {
     }
 
     #toggleContactDetails(event: Event) {
-        const contactCard = (<HTMLElement>event.target).closest('.contact') as HTMLElement;
+        const contactCard = (<HTMLElement>event.target).closest('.contact') as HTMLElement,
+            icon = ui.element('i', contactCard);
 
         ui.element('ul', contactCard).classList.toggle('hidden');
+
+        icon.innerText = `expand_${'expand_more' === icon.innerText ? 'less' : 'more'}`;
     }
 
     #contactFromVCard(vCard: string): Contact {

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -23,6 +23,7 @@ export default class VCard {
             const contact = this.#contactFromVCard(vCard[0]),
                 contactCard = contact.vCard();
 
+            ui.element('.expand', contactCard).onclick = (e) => this.#toggleContactDetails(e);
             ui.element('.save', contactCard).onclick = () => contact.download();
             ui.element('.remove', contactCard).onclick = () => this.#removeContact(contact);
 
@@ -61,6 +62,12 @@ export default class VCard {
         ui.element(`#${contact.id}`, this.column).remove();
 
         delete this.contacts[contact.id];
+    }
+
+    #toggleContactDetails(event: Event) {
+        const contactCard = (<HTMLElement>event.target).closest('.contact') as HTMLElement;
+
+        ui.element('ul', contactCard).classList.toggle('hidden');
     }
 
     #contactFromVCard(vCard: string): Contact {

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -23,9 +23,9 @@ export default class VCard {
             const contact = this.#contactFromVCard(vCard[0]),
                 contactCard = contact.vCard();
 
-            ui.element('.expand', contactCard).onclick = (e) => this.#toggleContactDetails(e);
-            ui.element('.save', contactCard).onclick = () => contact.download();
-            ui.element('.remove', contactCard).onclick = () => this.#removeContact(contact);
+            ui.element('.contact-header', contactCard).onclick = (e) => this.#toggleContactDetails(e);
+            ui.element('.save', contactCard).onclick = (e) => contact.download(e);
+            ui.element('.remove', contactCard).onclick = (e) => this.#removeContact(contact, e);
 
             ui.element('.contacts', this.column).append(contactCard);
             this.contacts[contact.id] = contact;
@@ -58,7 +58,9 @@ export default class VCard {
         ui.element(`#${contact.id}`, this.column).replaceWith(contact.vCard());
     }
 
-    #removeContact(contact: Contact) {
+    #removeContact(contact: Contact, event: Event) {
+        event.stopPropagation();
+
         ui.element(`#${contact.id}`, this.column).remove();
 
         delete this.contacts[contact.id];


### PR DESCRIPTION
Adds phone and email as the preferred options instead of organisation for the detail shown in contact headers, falling back to the first property that doesn't match the primary value (name or email) when there's no phone/email/org.

A new button is added to expand/collapse the contact details, with padding of the contact moved to a bottom margin on the details `ul` to fix an issue where contacts with no details would still show some lighter green space. Contact details are hidden by default.

The second line of contact headers also gets overflow applied to truncate longer values, and buttons are hidden when not hovering the header to make the most of the space.