### PR TITLE
Improve contact sorting/dragging

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -90,10 +90,10 @@ h1 {
 }
 ul.contacts {
     background-color: #f5efe9;
-    height: calc(100% - 50px);
+    height: calc(100% - 40px);
     margin: 0;
     overflow: auto;
-    padding: 0.5rem;
+    padding: 3px;
 }
 ul.contacts::-webkit-scrollbar {
     width: 0;
@@ -105,21 +105,9 @@ li.contact {
     color: #18282b;
     color: #677d76;
     list-style: none;
-    margin: 0 0 1vw;
+    margin: 0 0 3px;
     overflow: auto;
     padding: 0;
-}
-li.contact.hovering {
-    margin: 4vh 0 1vh;
-}
-li.contact.hovering::before {
-    content: '☞';
-    color: #3a4f4d;
-    font-size: 2rem;
-    font-weight: bold;
-    position: absolute;
-    margin-left: -0.9rem;
-    margin-top: -2.5rem;
 }
 .contact-header {
     background-color: #3a4f4d;

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,10 +10,12 @@ ui.element('#extracard').onclick = () => {
 };
 
 ui.element('#new-file-form').onsubmit = (ev) => {
-    const input = <HTMLInputElement & {parentNode: HTMLElement}>
-        ui.element('input[type=text]', (<HTMLElement>ev.target));
-    let filename = input.value;
+    const input = ui.element(
+        'input[type=text]',
+        ev.target as HTMLElement,
+    ) as any as HTMLInputElement;
 
+    let filename = input.value;
     if (!filename.endsWith('.vcf')) {
         filename += '.vcf';
     }

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -21,7 +21,8 @@ export default class CardBoard {
         ui.element('input.upload', clone).onchange = (ev) => this.loadVCardFile(ev);
         ui.element('.contacts', clone).addEventListener('dragstart', ev => this.#handleDragStart(ev));
         ui.element('.contacts', clone).addEventListener('dragend', ev => this.#handleDragEnd(ev));
-        ui.element('.vcard', clone).addEventListener('dragover', ev => this.#handleDragOver(ev), false);
+        ui.element('.vcard', clone).addEventListener('dragenter', ev => this.#handleDragEnter(ev));
+        ui.element('.vcard', clone).addEventListener('dragover', ev => ev.preventDefault(), false);
         ui.element('.vcard', clone).addEventListener('drop', ev => this.#handleDrop(ev));
         ui.element('.vcard', clone).id = id;
 
@@ -54,29 +55,18 @@ export default class CardBoard {
     #handleDragEnd(event: DragEvent) {
         (<HTMLElement>event.target).classList.remove('dragging');
 
-        this.#resetHover();
         this.dragging = null;
     }
 
-    #handleDragOver(event: DragEvent) {
-        const hovering = document.elementFromPoint(event.clientX, event.clientY),
-            contact = <HTMLElement|null>hovering?.closest('.contact');
+    #handleDragEnter(event: DragEvent) {
+        const d = <HTMLElement>this.dragging,
+            t: HTMLElement|null = (<HTMLElement>event.target).closest('.contact');
 
-        event.preventDefault();
-
-        if (contact) {
-            this.#resetHover();
-            this.lastHovered = contact;
-        }
-        if (!contact || !this.dragging || [
-            contact.id,
-            contact.previousElementSibling?.id,
-        ].includes(this.dragging.id)) {
+        if (!t || t.offsetTop === d.offsetTop) {
             return;
         }
 
-        contact.classList.add('hovering');
-        contact.style.marginTop = `calc(${this.dragging.offsetHeight}px + 2vh)`;
+        t.offsetTop > d.offsetTop ? t.before(d) : t.after(d);
     }
 
     #handleDrop(event: DragEvent) {
@@ -135,15 +125,6 @@ export default class CardBoard {
         }
 
         return <VCard>this.vCards[element.id];
-    }
-
-    #resetHover() {
-        const wasHovering = <HTMLElement|null>document.querySelector('.hovering');
-
-        if (wasHovering) {
-            wasHovering.style.marginTop = '1vh';
-            wasHovering.classList.remove('hovering');
-        }
     }
 
     removeCardColumn(vCardID: string) {

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -93,8 +93,8 @@ export default class CardBoard {
         assertIsDefined(this.dragging);
         event.preventDefault();
 
-        const card = <HTMLElement>event.target.closest('.vcard'),
-            [first, closest] = ui.closest('.contact', event, card),
+        const card = this.#nearestVCard(event.target),
+            [first, closest] = card.findClosestContact(event),
             draggedContact = this.dragging.contact;
 
         if (closest?.id === draggedContact.id) {
@@ -105,7 +105,7 @@ export default class CardBoard {
             case 'cursor': return closest.before(draggedContact);
             case 'element': return closest.after(draggedContact);
             default:
-                return ui.element('.contacts', card).append(draggedContact);
+                return ui.element('.contacts', card.column).append(draggedContact);
         }
     }
 

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -76,31 +76,23 @@ export default class CardBoard {
     }
 
     #handleDragOver(event: TargettedDragEvent) {
-        event.preventDefault();
         assertIsDefined(this.dragging);
+        event.preventDefault();
 
         const card = <HTMLElement>event.target.closest('.vcard'),
-            contact: HTMLElement | null =
-                event.target.closest('.contact') || ui.closest('.contact', event, card),
-            dragging = this.dragging.contact;
+            [first, closest] = ui.closest('.contact', event, card),
+            draggedContact = this.dragging.contact;
 
-        if (!contact) {
-            return ui.element('.contacts', card).append(dragging);
-        }
-
-        if (contact.id === dragging.id) {
+        if (closest?.id === draggedContact.id) {
             return;
         }
 
-        const contactRect = contact.getBoundingClientRect(),
-            contactCenterY = contactRect.top + contactRect.height / 2,
-            draggedContact = this.dragging.contact;
-
-        if (event.y < contactCenterY) {
-            return contact.before(draggedContact);
+        switch(first) {
+            case 'cursor': return closest.before(draggedContact);
+            case 'element': return closest.after(draggedContact);
+            default:
+                return ui.element('.contacts', card).append(draggedContact);
         }
-
-        contact.after(draggedContact);
     }
 
     #handleDrop(event: DragEvent) {

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -53,7 +53,7 @@ export default class CardBoard {
 
     #handleDragStart(event: DragEvent) {
         const contact = <HTMLElement>event.target,
-            origin = contact.nextElementSibling || contact.previousElementSibling || null;
+            origin = contact.nextElementSibling || contact.previousElementSibling;
 
         this.dragging = {card: this.#nearestVCard(contact), contact, didMove: false, origin};
 
@@ -78,7 +78,9 @@ export default class CardBoard {
             card = this.#nearestVCard(event.target as HTMLElement);
 
         if (card && !t && card !== this.dragging.card) {
-            ui.element('.contacts', card.column).append(d);
+            const closest = ui.closest('.contact', event, card.column);
+
+            closest ? closest.after(d) : ui.element('.contacts', card.column).append(d);
         }
         if (!t || t.offsetTop === d.offsetTop) {
             return;

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -144,9 +144,8 @@ export default class CardBoard {
             return;
         }
 
-        newCard.contacts[contact.id] = contact;
-
-        delete oldCard.contacts[contact.id];
+        newCard.addContact(contact);
+        oldCard.removeContact(contact);
     }
 
     #nearestVCard(element: HTMLElement|null): VCard {
@@ -168,8 +167,7 @@ export default class CardBoard {
             throw new Error(`Card '${vCardID}' not found.`);
         }
 
-        card.column.remove();
-
+        card.tearDown();
         delete this.vCards[vCardID];
     }
 

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -9,7 +9,7 @@ function assertIsDefined<T>(value: T): asserts value is NonNullable<T> {
     }
 }
 
-type DragData = {card: VCard, contact: HTMLElement, didDrag: boolean, origin: ChildNode|null};
+type DragData = {card: VCard, contact: HTMLElement, didMove: boolean, origin: ChildNode|null};
 
 export default class CardBoard {
     cardBoard = ui.element('#vcards');
@@ -55,13 +55,13 @@ export default class CardBoard {
         const contact = <HTMLElement>event.target,
             origin = contact.nextElementSibling || contact.previousElementSibling || null;
 
-        this.dragging = {card: this.#nearestVCard(contact), contact, didDrag: false, origin};
+        this.dragging = {card: this.#nearestVCard(contact), contact, didMove: false, origin};
 
         contact.classList.add('dragging');
     }
 
     #handleDragEnd(event: DragEvent) {
-        if (this.dragging?.origin && !this.dragging.didDrag) {
+        if (this.dragging?.origin && !this.dragging.didMove) {
             this.dragging.origin.before(this.dragging.contact);
         }
 
@@ -98,11 +98,7 @@ export default class CardBoard {
             this.#mergeContacts(oldCard, newCard, contact);
         } else if (contact || oldCard !== newCard) {
             this.#moveContact(oldCard, newCard);
-        } else {
-            return;
         }
-
-        this.dragging.didDrag = true;
     }
 
     #mergeContacts(oldCard: VCard, newCard: VCard, mergeInto: Element) {
@@ -118,6 +114,7 @@ export default class CardBoard {
 
     #moveContact(oldCard: VCard, newCard: VCard) {
         assertIsDefined(this.dragging);
+        this.dragging.didMove = true;
 
         const contact = oldCard.contacts[this.dragging.contact.id];
 

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -30,7 +30,6 @@ export default class CardBoard {
         ui.element('input.upload', clone).onchange = (ev) => this.loadVCardFile(ev);
         ui.element('.contacts', clone).addEventListener('dragstart', e => this.#handleDragStart(<TargettedDragEvent>e));
         ui.element('.contacts', clone).addEventListener('dragend', e => this.#handleDragEnd(<TargettedDragEvent>e));
-        ui.element('.vcard', clone).addEventListener('dragenter', e => this.#handleDragEnter(<TargettedDragEvent>e));
         ui.element('.vcard', clone).addEventListener('dragover', e => this.#handleDragOver(<TargettedDragEvent>e));
         ui.element('.vcard', clone).addEventListener('drop', ev => this.#handleDrop(ev));
         ui.element('.vcard', clone).id = id;
@@ -72,31 +71,20 @@ export default class CardBoard {
         this.dragging = null;
     }
 
-    #handleDragEnter(event: TargettedDragEvent) {
-        assertIsDefined(this.dragging);
-
-        const card = this.#nearestVCard(event.target);
-
-        if (event.target.closest('.contact') || card === this.dragging.card) {
-            return;
-        }
-
-        const closest = ui.closest('.contact', event, card.column);
-        if (closest) {
-            return closest.after(this.dragging.contact);
-        }
-
-        ui.element('.contacts', card.column).append(this.dragging.contact);
-    }
-
     #handleDragOver(event: TargettedDragEvent) {
         event.preventDefault();
         assertIsDefined(this.dragging);
 
-        const contact: HTMLElement | null = event.target.closest('.contact'),
+        const card = <HTMLElement>event.target.closest('.vcard'),
+            contact: HTMLElement | null =
+                event.target.closest('.contact') || ui.closest('.contact', event, card),
             dragging = this.dragging.contact;
 
-        if (null === contact || contact.id === dragging.id) {
+        if (!contact) {
+            return ui.element('.contacts', card).append(dragging);
+        }
+
+        if (contact.id === dragging.id) {
             return;
         }
 

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -94,11 +94,11 @@ export default class CardBoard {
             [oldCard, newCard] = [this.dragging.card, this.#nearestVCard(target)],
             contact = target.closest('.contact');
 
-        if (contact && contact !== this.dragging.contact) {
-            this.#mergeContacts(oldCard, newCard, contact);
-        } else if (contact || oldCard !== newCard) {
-            this.#moveContact(oldCard, newCard);
+        if (!contact || contact === this.dragging.contact) {
+            return this.#moveContact(oldCard, newCard);
         }
+
+        this.#mergeContacts(oldCard, newCard, contact);
     }
 
     #mergeContacts(oldCard: VCard, newCard: VCard, mergeInto: Element) {

--- a/src/cardboard.ts
+++ b/src/cardboard.ts
@@ -24,16 +24,20 @@ export default class CardBoard {
         const clone = this.template.cloneNode(true) as HTMLElement,
             id = 'vcard-' + Date.now().toString().slice(-7);
 
-        this.cardCount += 1;
         ui.element('button.close', clone).onclick = () => this.removeCardColumn(id);
         ui.element('button.save', clone).onclick = () => this.downloadCard(id);
         ui.element('input.upload', clone).onchange = (ev) => this.loadVCardFile(ev);
-        ui.element('.contacts', clone).addEventListener('dragstart', e => this.#handleDragStart(<TargettedDragEvent>e));
-        ui.element('.contacts', clone).addEventListener('dragend', e => this.#handleDragEnd(<TargettedDragEvent>e));
-        ui.element('.vcard', clone).addEventListener('dragover', e => this.#handleDragOver(<TargettedDragEvent>e));
-        ui.element('.vcard', clone).addEventListener('drop', ev => this.#handleDrop(ev));
-        ui.element('.vcard', clone).id = id;
 
+        ui.element('.contacts', clone)
+            .listen('dragstart', ev => this.#handleDragStart(<TargettedDragEvent> ev))
+            .listen('dragend', ev => this.#handleDragEnd(<TargettedDragEvent> ev));
+
+        ui.element('.vcard', clone)
+            .listen('dragover', ev => this.#handleDragOver(<TargettedDragEvent> ev))
+            .listen('drop', ev => this.#handleDrop(<TargettedDragEvent> ev))
+            .id = id;
+
+        this.cardCount += 1;
         this.cardBoard.style.columnCount = this.cardCount.toString();
         this.cardBoard.append(clone);
 

--- a/src/contact.ts
+++ b/src/contact.ts
@@ -4,6 +4,7 @@ import * as ui from "./ui.js";
 
 export default class Contact {
     id: string;
+    isVisible: boolean = false;
     rawData: string;
     properties: VCardProperty[];
     hasInvalidLines: boolean = false;

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -11,7 +11,7 @@ export default class MergeWindow {
 
     constructor(oldVCard: VCard, oldContact: Contact, newVCard: VCard, newContact: Contact) {
         this.contacts = {left: oldContact.clone(), right: newContact.clone()};
-        this.dialog = <HTMLDialogElement>ui.element('#merge');
+        this.dialog = ui.element('#merge') as any as HTMLDialogElement;
         this.newVCard = newVCard;
         this.oldVCard = oldVCard;
     }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,7 +20,7 @@ export function applyValues(tpl: string, values: {[key: string]: string}) {
 export function closest(
     selector: string,
     {clientY, target}: MouseEvent & HTMLTarget,
-    haystack: IntersectionObserverEntry[] = [],
+    haystack: HTMLElement[] = [],
 ): ['cursor'|'element', HTMLElement] | [null, null] {
     let closest: CursorRelativeElement|HTMLElement|null = <HTMLElement | null> target.closest(selector);
 
@@ -31,12 +31,12 @@ export function closest(
     }
 
     let shortestDistance = Infinity;
-    for (const entry of haystack) {
-        const [first, distance] = directionAndDistanceTo(entry, clientY);
+    for (const target of haystack) {
+        const [first, distance] = directionAndDistanceTo(target, clientY);
         if (shortestDistance < distance)
             continue;
 
-        closest = [first, entry.target as HTMLElement];
+        closest = [first, target];
         shortestDistance = distance;
     }
 
@@ -45,11 +45,8 @@ export function closest(
 
 // Returns a tuple with which comes first between 'cursor'/'element',
 // and the distance between `y` and the vertical center of `target`.
-function directionAndDistanceTo(
-    target: HTMLElement|IntersectionObserverEntry,
-    y: number
-): ['cursor'|'element', number] {
-    const rect = getRect(target),
+function directionAndDistanceTo(target: HTMLElement, y: number): ['cursor'|'element', number] {
+    const rect = target.getBoundingClientRect(),
         centerY = rect.top + rect.height / 2,
         distance = Math.abs(y - centerY);
 
@@ -77,14 +74,6 @@ function findOrFail(selector: string, parent: Document|HTMLElement): any {
     }
 
     return el
-}
-
-function getRect(target: HTMLElement|IntersectionObserverEntry): DOMRect {
-    if (target instanceof IntersectionObserverEntry) {
-        return target.boundingClientRect;
-    }
-
-    return target.getBoundingClientRect();
 }
 
 export function icon(name: string): HTMLElement {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9,6 +9,25 @@ export function applyValues(tpl: string, values: {[key: string]: string}) {
     return clone;
 }
 
+// Find the closest `selector` (contained within `parent`?) to the position of `MouseEvent`.
+export function closest(selector: string, {clientX, clientY}: MouseEvent, parent?: Element): HTMLElement|null {
+    let closest = null, closestDistance = Infinity;
+
+    (parent || document).querySelectorAll(selector).forEach(element => {
+        const rect = element.getBoundingClientRect(),
+            // (cursorX - elCentreX)² + (cursorY - elCentreY)²
+            distanceSquared = Math.pow(clientX - (rect.left + rect.width / 2), 2) +
+                Math.pow(clientY - (rect.top + rect.height / 2), 2);
+
+        if (distanceSquared < closestDistance) {
+            closestDistance = distanceSquared;
+            closest = element;
+        }
+    });
+
+    return closest;
+}
+
 export const element = (selector: string, parent: Document|HTMLElement = document):
     HTMLElement => findOrFail(selector, parent);
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,7 +20,7 @@ export function applyValues(tpl: string, values: {[key: string]: string}) {
 export function closest(
     selector: string,
     {clientY, target}: MouseEvent & HTMLTarget,
-    parent?: Element
+    haystack: HTMLElement[] = [],
 ): ['cursor'|'element', HTMLElement] | [null, null] {
     let closest: CursorRelativeElement|HTMLElement|null = <HTMLElement | null> target.closest(selector);
 
@@ -31,14 +31,7 @@ export function closest(
     }
 
     let shortestDistance = Infinity;
-    for (const el of (parent || document).querySelectorAll(selector) as NodeListOf<HTMLElement>) {
-        const list = el.parentElement as HTMLElement,
-            tooHigh = list.offsetTop > el.offsetTop + el.offsetHeight - list.scrollTop,
-            tooLow = list.offsetHeight < el.offsetTop - list.offsetTop - list.scrollTop;
-
-        if (tooHigh) continue;
-        if (tooLow) break;
-
+    for (const el of haystack) {
         const [first, distance] = directionAndDistanceTo(el, clientY);
         if (shortestDistance < distance)
             continue;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,3 +1,7 @@
+type ElementWithListener = HTMLElement & {
+    listen(event: string, listener: EventListener): ElementWithListener
+};
+
 export function applyValues(tpl: string, values: {[key: string]: string}) {
     const clone = template(`#${tpl}`).content.cloneNode(true) as HTMLElement,
         container = element(':first-child', clone).className;
@@ -28,8 +32,14 @@ export function closest(selector: string, {clientX, clientY}: MouseEvent, parent
     return closest;
 }
 
-export const element = (selector: string, parent: Document|HTMLElement = document):
-    HTMLElement => findOrFail(selector, parent);
+export function element(selector: string, parent: Document|HTMLElement = document): ElementWithListener {
+    const el: ElementWithListener = findOrFail(selector, parent);
+
+    el.listen = (event: string, listener: EventListener) =>
+        listen(el, event, listener);
+
+    return el;
+}
 
 function findOrFail(selector: string, parent: Document|HTMLElement): any {
     const el = parent.querySelector(selector);
@@ -52,6 +62,16 @@ export function icon(name: string): HTMLElement {
 
 export const image = (selector: string, parent: Document|HTMLElement = document):
     HTMLImageElement => findOrFail(selector, parent);
+
+function listen <T extends ElementWithListener> (
+    element: T,
+    event: string,
+    listener: EventListener,
+): T {
+    element.addEventListener(event, listener);
+
+    return element;
+}
 
 export const template = (selector: string):
     HTMLTemplateElement => findOrFail(selector, document);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,8 @@
+type CursorRelativeElement = ['cursor'|'element', HTMLElement];
 type ElementWithListener = HTMLElement & {
     listen(event: string, listener: EventListener): ElementWithListener
 };
+type HTMLTarget = {target: HTMLElement};
 
 export function applyValues(tpl: string, values: {[key: string]: string}) {
     const clone = template(`#${tpl}`).content.cloneNode(true) as HTMLElement,
@@ -13,23 +15,46 @@ export function applyValues(tpl: string, values: {[key: string]: string}) {
     return clone;
 }
 
-// Find the closest `selector` (contained within `parent`?) to the position of `MouseEvent`.
-export function closest(selector: string, {clientX, clientY}: MouseEvent, parent?: Element): HTMLElement|null {
-    let closest = null, closestDistance = Infinity;
+// Find the closest `selector` within `parent` (or document) to the position of
+// `MouseEvent`, and whether the 'cursor' or 'element' centre position is first.
+export function closest(
+    selector: string,
+    {clientY, target}: MouseEvent & HTMLTarget,
+    parent?: Element
+): ['cursor'|'element', HTMLElement] | [null, null] {
+    let closest: CursorRelativeElement|HTMLElement|null = <HTMLElement | null> target.closest(selector);
 
+    if (closest) {
+        const [first] = directionAndDistanceTo(closest, clientY);
+
+        return [first, closest];
+    }
+
+    let closestDistance = Infinity;
     (parent || document).querySelectorAll(selector).forEach(element => {
-        const rect = element.getBoundingClientRect(),
-            // (cursorX - elCentreX)² + (cursorY - elCentreY)²
-            distanceSquared = Math.pow(clientX - (rect.left + rect.width / 2), 2) +
-                Math.pow(clientY - (rect.top + rect.height / 2), 2);
+        const [first, distance] = directionAndDistanceTo(element as HTMLElement, clientY);
 
-        if (distanceSquared < closestDistance) {
-            closestDistance = distanceSquared;
-            closest = element;
+        if (distance < closestDistance) {
+            closestDistance = distance;
+            closest = [first, element as HTMLElement];
         }
     });
 
-    return closest;
+    return closest || [null, null];
+}
+
+// Returns a tuple with which comes first between 'cursor'/'element',
+// and the distance between `y` and the vertical center of `target`.
+function directionAndDistanceTo(target: HTMLElement, y: number): ['cursor'|'element', number] {
+    const rect = target.getBoundingClientRect(),
+        centerY = rect.top + rect.height / 2,
+        distance = Math.abs(y - centerY);
+
+    if (y < centerY) {
+        return ['cursor', distance];
+    }
+
+    return ['element', distance];
 }
 
 export function element(selector: string, parent: Document|HTMLElement = document): ElementWithListener {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -30,15 +30,22 @@ export function closest(
         return [first, closest];
     }
 
-    let closestDistance = Infinity;
-    (parent || document).querySelectorAll(selector).forEach(element => {
-        const [first, distance] = directionAndDistanceTo(element as HTMLElement, clientY);
+    let shortestDistance = Infinity;
+    for (const el of (parent || document).querySelectorAll(selector) as NodeListOf<HTMLElement>) {
+        const list = el.parentElement as HTMLElement,
+            tooHigh = list.offsetTop > el.offsetTop + el.offsetHeight - list.scrollTop,
+            tooLow = list.offsetHeight < el.offsetTop - list.offsetTop - list.scrollTop;
 
-        if (distance < closestDistance) {
-            closestDistance = distance;
-            closest = [first, element as HTMLElement];
-        }
-    });
+        if (tooHigh) continue;
+        if (tooLow) break;
+
+        const [first, distance] = directionAndDistanceTo(el, clientY);
+        if (shortestDistance < distance)
+            continue;
+
+        closest = [first, el];
+        shortestDistance = distance;
+    }
 
     return closest || [null, null];
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,7 +20,7 @@ export function applyValues(tpl: string, values: {[key: string]: string}) {
 export function closest(
     selector: string,
     {clientY, target}: MouseEvent & HTMLTarget,
-    haystack: HTMLElement[] = [],
+    haystack: IntersectionObserverEntry[] = [],
 ): ['cursor'|'element', HTMLElement] | [null, null] {
     let closest: CursorRelativeElement|HTMLElement|null = <HTMLElement | null> target.closest(selector);
 
@@ -31,12 +31,12 @@ export function closest(
     }
 
     let shortestDistance = Infinity;
-    for (const el of haystack) {
-        const [first, distance] = directionAndDistanceTo(el, clientY);
+    for (const entry of haystack) {
+        const [first, distance] = directionAndDistanceTo(entry, clientY);
         if (shortestDistance < distance)
             continue;
 
-        closest = [first, el];
+        closest = [first, entry.target as HTMLElement];
         shortestDistance = distance;
     }
 
@@ -45,8 +45,11 @@ export function closest(
 
 // Returns a tuple with which comes first between 'cursor'/'element',
 // and the distance between `y` and the vertical center of `target`.
-function directionAndDistanceTo(target: HTMLElement, y: number): ['cursor'|'element', number] {
-    const rect = target.getBoundingClientRect(),
+function directionAndDistanceTo(
+    target: HTMLElement|IntersectionObserverEntry,
+    y: number
+): ['cursor'|'element', number] {
+    const rect = getRect(target),
         centerY = rect.top + rect.height / 2,
         distance = Math.abs(y - centerY);
 
@@ -74,6 +77,14 @@ function findOrFail(selector: string, parent: Document|HTMLElement): any {
     }
 
     return el
+}
+
+function getRect(target: HTMLElement|IntersectionObserverEntry): DOMRect {
+    if (target instanceof IntersectionObserverEntry) {
+        return target.boundingClientRect;
+    }
+
+    return target.getBoundingClientRect();
 }
 
 export function icon(name: string): HTMLElement {

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -9,7 +9,7 @@ export default class VCard {
     id: string;
     filename: string | undefined;
     #observer: IntersectionObserver;
-    #visibleContacts: object & {[id: string]: IntersectionObserverEntry} = {};
+    #visibleContacts: object & {[id: string]: HTMLElement} = {};
 
     constructor(id: string, filename?: string) {
         this.id = id;
@@ -45,7 +45,7 @@ export default class VCard {
     #changeContactVisibility(entries: IntersectionObserverEntry[]) {
         for (const entry of entries) {
             if (entry.isIntersecting) {
-                this.#visibleContacts[entry.target.id] = entry;
+                this.#visibleContacts[entry.target.id] = entry.target as HTMLElement;
             } else if (entry.target.id in this.#visibleContacts) {
                 delete this.#visibleContacts[entry.target.id];
             }

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -9,7 +9,7 @@ export default class VCard {
     id: string;
     filename: string | undefined;
     #observer: IntersectionObserver;
-    #visibleContacts: object & {[id: string]: HTMLElement} = {};
+    #visibleContacts: object & {[id: string]: IntersectionObserverEntry} = {};
 
     constructor(id: string, filename?: string) {
         this.id = id;
@@ -45,7 +45,7 @@ export default class VCard {
     #changeContactVisibility(entries: IntersectionObserverEntry[]) {
         for (const entry of entries) {
             if (entry.isIntersecting) {
-                this.#visibleContacts[entry.target.id] = ui.element(`#${entry.target.id}`);
+                this.#visibleContacts[entry.target.id] = entry;
             } else if (entry.target.id in this.#visibleContacts) {
                 delete this.#visibleContacts[entry.target.id];
             }

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -11,7 +11,7 @@ export default class VCard {
 
     constructor(id: string, filename?: string) {
         this.id = id;
-        this.column = <HTMLDivElement>ui.element(`#${id}`);
+        this.column = ui.element(`#${id}`) as any as HTMLDivElement;
 
         this.#setHeader(filename);
     }

--- a/src/vcard.ts
+++ b/src/vcard.ts
@@ -21,6 +21,11 @@ export default class VCard {
         this.#setHeader(filename);
     }
 
+    addContact(contact: Contact) {
+        this.contacts[contact.id] = contact;
+        this.#observer.observe(ui.element(`#${contact.id}`));
+    }
+
     process(filename: string, vcfData: string) {
         this.#setHeader(filename);
 
@@ -30,12 +35,10 @@ export default class VCard {
 
             ui.element('.contact-header', contactCard).onclick = (e) => this.#toggleContactDetails(e);
             ui.element('.save', contactCard).onclick = (e) => contact.download(e);
-            ui.element('.remove', contactCard).onclick = (e) => this.#removeContact(contact, e);
+            ui.element('.remove', contactCard).onclick = (e) => this.#removeContactItem(contact, e);
 
             ui.element('.contacts', this.column).append(contactCard);
-
-            this.contacts[contact.id] = contact;
-            this.#observer.observe(ui.element(`#${contact.id}`));
+            this.addContact(contact);
         }
     }
 
@@ -79,12 +82,17 @@ export default class VCard {
         ui.element(`#${contact.id}`, this.column).replaceWith(contact.vCard());
     }
 
-    #removeContact(contact: Contact, event: Event) {
+    removeContact(contact: Contact) {
+        this.#observer.unobserve(ui.element(`#${contact.id}`));
+
+        delete this.contacts[contact.id];
+    }
+    #removeContactItem(contact: Contact, event: Event) {
         event.stopPropagation();
 
         ui.element(`#${contact.id}`, this.column).remove();
 
-        delete this.contacts[contact.id];
+        this.removeContact(contact);
     }
 
     #toggleContactDetails(event: Event) {
@@ -117,6 +125,11 @@ export default class VCard {
         }
 
         ui.element('h2', this.column).innerText = this.filename || 'Loading...';
+    }
+
+    tearDown() {
+        this.#observer.disconnect();
+        this.column.remove();
     }
 
     // Split continuous lines on CRLF followed by space or tab.


### PR DESCRIPTION
Reworks contact dragging such that contact elements are inserted as they're being dragged, only resetting the position if a move operation didn't complete after the drop.

To solve various bugs and odd behaviours with the early incarnation of that, starting position (before `nextElementSibling`, after `previousElementSibling`, or "solo" with `parentElement`) is also tracked, allowing the contact to be accurately reset to the original position.

While dragging over a valid area that's *not* a contact (for instance the margin around a contact, or the card header), the closest contact is now calculated based on vertical centres vs the cursor's `y` position. This also fixes bugs that would occur when dropping contacts to a new card or one with only a single contact or two.